### PR TITLE
changed type to types to query a place by type

### DIFF
--- a/GooglePlacesAutocomplete/GooglePlacesAutocomplete.swift
+++ b/GooglePlacesAutocomplete/GooglePlacesAutocomplete.swift
@@ -235,7 +235,7 @@ extension GooglePlacesAutocompleteContainer: UISearchBarDelegate {
   private func requestForSearch(searchString: String) -> NSURLRequest {
     let params = [
       "input": searchString,
-      "type": "(\(placeType.description))",
+      "types": "(\(placeType.description))",
       "key": apiKey ?? ""
     ]
 

--- a/GooglePlacesAutocompleteExample/GooglePlacesAutocompleteExampleTests/GooglePlacesAutocompleteExampleTests.swift
+++ b/GooglePlacesAutocompleteExample/GooglePlacesAutocompleteExampleTests/GooglePlacesAutocompleteExampleTests.swift
@@ -21,7 +21,7 @@ class GooglePlacesAutocompleteTests: FBSnapshotTestCase, GooglePlacesAutocomplet
 
     OHHTTPStubs.stubRequestsPassingTest({ (request: NSURLRequest!) -> Bool in
       println(request.URL.absoluteString)
-      return request.URL.absoluteString == "https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Paris&key=APIKEY&type=%28%29"
+      return request.URL.absoluteString == "https://maps.googleapis.com/maps/api/place/autocomplete/json?input=Paris&key=APIKEY&types=%28%29"
       }, withStubResponse: { (request: NSURLRequest!) -> OHHTTPStubsResponse in
         return OHHTTPStubsResponse(JSONObject: json, statusCode: 200, headers: nil)
     })


### PR DESCRIPTION
I got wrong results when searching for cites, so i checked to docs and it seems the correct param name is types.
[For reference](https://developers.google.com/places/documentation/autocomplete)
