### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ No attempt has been made to integrate MapKit since displaying Google Places on a
 ## Requirements
 
 - iOS 7.0+
-- XCode 7.0+ / Swift 2.0
+- Xcode 7.0+ / Swift 2.0
 
 ## Installation
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
