### PR TITLE
Replaced code deprecated in iOS 9.0

### DIFF
--- a/GooglePlacesAutocomplete/GooglePlacesAutocomplete.swift
+++ b/GooglePlacesAutocomplete/GooglePlacesAutocomplete.swift
@@ -333,7 +333,7 @@ class GooglePlacesRequestHelpers {
   }
 
   private class func escape(string: String) -> String {
-    let legalURLCharactersToBeEscaped = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',*")
+    let legalURLCharactersToBeEscaped: NSCharacterSet = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',*")
     return NSString(string: string).stringByAddingPercentEncodingWithAllowedCharacters(legalURLCharactersToBeEscaped)! as String
     
   }

--- a/GooglePlacesAutocomplete/GooglePlacesAutocomplete.swift
+++ b/GooglePlacesAutocomplete/GooglePlacesAutocomplete.swift
@@ -333,7 +333,7 @@ class GooglePlacesRequestHelpers {
   }
 
   private class func escape(string: String) -> String {
-    let legalURLCharactersToBeEscaped: NSCharacterSet = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',*")
+    let legalURLCharactersToBeEscaped = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',*")
     return NSString(string: string).stringByAddingPercentEncodingWithAllowedCharacters(legalURLCharactersToBeEscaped)! as String
     
   }

--- a/GooglePlacesAutocomplete/GooglePlacesAutocomplete.swift
+++ b/GooglePlacesAutocomplete/GooglePlacesAutocomplete.swift
@@ -333,8 +333,9 @@ class GooglePlacesRequestHelpers {
   }
 
   private class func escape(string: String) -> String {
-    let legalURLCharactersToBeEscaped: CFStringRef = ":/?&=;+!@#$()',*"
-    return CFURLCreateStringByAddingPercentEscapes(nil, string, nil, legalURLCharactersToBeEscaped, CFStringBuiltInEncodings.UTF8.rawValue) as String
+    let legalURLCharactersToBeEscaped: NSCharacterSet = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',*")
+    return NSString(string: string).stringByAddingPercentEncodingWithAllowedCharacters(legalURLCharactersToBeEscaped)! as String
+    
   }
 
   private class func doRequest(url: String, params: [String: String], completion: (NSDictionary?,NSError?) -> ()) {

--- a/GooglePlacesAutocomplete/GooglePlacesAutocomplete.swift
+++ b/GooglePlacesAutocomplete/GooglePlacesAutocomplete.swift
@@ -334,8 +334,8 @@ class GooglePlacesRequestHelpers {
 
   private class func escape(string: String) -> String {
     let legalURLCharactersToBeEscaped: NSCharacterSet = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',*")
-    return NSString(string: string).stringByAddingPercentEncodingWithAllowedCharacters(legalURLCharactersToBeEscaped)! as String
     
+    return NSString(string: string).stringByAddingPercentEncodingWithAllowedCharacters(legalURLCharactersToBeEscaped)! as String
   }
 
   private class func doRequest(url: String, params: [String: String], completion: (NSDictionary?,NSError?) -> ()) {


### PR DESCRIPTION
`CFURLCreateStringsByAddingPercentEscapes()` function was deprecated in iOS 9.0, and Xcode was throwing up a warning each time I built my app. I updated the code in `escape(string: String) -> String` function to use `NSString().stringByAddingPercentEncodingWithAllowedCharacters()` instead. Autocomplete still works correctly and the warning has disappeared.

Massive thanks to <b>watsonbox</b> for publishing this code originally!
